### PR TITLE
JVM Arguments need to be in form of a list 

### DIFF
--- a/inventory-wildfly-swarm/pom.xml
+++ b/inventory-wildfly-swarm/pom.xml
@@ -96,7 +96,9 @@
           <properties>
             <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
           </properties>
-          <jvmArguments>-Dswarm.http.port=9001</jvmArguments>
+          <jvmArguments>
+            <jvmArgument>-Dswarm.http.port=9001</jvmArgument>
+          </jvmArguments>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
JVM Arguments of the wildfly-swarm-plugin needs to be al ist of jvmArgument elements as documented in https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/v/2017.10.0/getting-started/tooling/maven-plugin.html