### PR TITLE
Updated dependencies for bootstrap and bootstrap-switch

### DIFF
--- a/web-nodejs/bower.json
+++ b/web-nodejs/bower.json
@@ -9,6 +9,7 @@
     "devDependencies": {
         "patternfly": "3.17.0",
         "angular-patternfly": "3.17.0",
+        "bootstrap-switch": "3.3.2",
         "isotope": "2.2.2",
         "imagesloaded": "4.1.1",
         "angular-route": "1.5.10",
@@ -16,6 +17,7 @@
     },
     "resolutions": {
         "angular": "1.5.10",
-        "jquery": "3.3.1"
+        "jquery": "3.3.1",
+        "bootstrap": "~3.3.7"
     }
 }


### PR DESCRIPTION
This is to fix https://github.com/openshift-labs/cloud-native-labs/issues/5.

Similar to what was submitted here: https://github.com/jbossdemocentral/coolstore-microservice/pull/120. I'm bringing this bower.json up to date with that one.

This should go in all branches - it's not specific to any one version of OpenShift.